### PR TITLE
fix: Iterate through npm cache dependencies

### DIFF
--- a/src/postinstall.js
+++ b/src/postinstall.js
@@ -38,7 +38,9 @@ async function warmNpmCache() {
   }
 
   try {
-    await shExec(`npm cache add ${toCache.join(' ')}`);
+    for await (const pkgWithVersion of toCache) {
+      await shExec(`npm cache add ${pkgWithVersion}`);
+    }
     console.log('    Done.');
   } catch (err) {
     console.error(err);


### PR DESCRIPTION
When running npm v6, npm will give an error if you give multiple dependencies to the `npm cache add` command. 

Instead of adding all dependencies in one line, we can iterate through the list of dependencies and add them one by one in an async operation.