### PR TITLE
fix: change project template's tsconfig.json target to ES2019 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "snapp-cli",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "snapp-cli",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snapp-cli",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "CLI to create a SNAPP (Snark App) for Mina Protocol.",
   "author": "O(1) Labs",
   "license": "Apache-2.0",

--- a/templates/project-ts/package-lock.json
+++ b/templates/project-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "package-name",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "package-name",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/jest": "^26.0.24",

--- a/templates/project-ts/package.json
+++ b/templates/project-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "package-name",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "",
   "author": "",
   "license": "Apache-2.0",

--- a/templates/project-ts/tsconfig.json
+++ b/templates/project-ts/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2021",
+    "target": "ES2019",
     "module": "ES2020",
     "outDir": "./build",
     "rootDir": "./src",


### PR DESCRIPTION
so Node 12 doesn't warn when running tests