### PR TITLE
feat: Add Windows support for project and example

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "snapp-cli",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "snapp-cli",
-      "version": "0.1.23",
+      "version": "0.1.24",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snapp-cli",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "description": "CLI to create a SNAPP (Snark App) for Mina Protocol.",
   "author": "O(1) Labs",
   "license": "Apache-2.0",

--- a/src/lib/example.js
+++ b/src/lib/example.js
@@ -49,7 +49,7 @@ async function example(example) {
   // `-n` (no verify) skips Husky's pre-commit hooks.
   await step(
     'Git init commit',
-    `git add . && git commit -m "Init commit" -q -n && git branch -m main`
+    'git add . && git commit -m "Init commit" -q -n && git branch -m main'
   );
 
   const str =

--- a/src/lib/file.js
+++ b/src/lib/file.js
@@ -60,7 +60,7 @@ async function file(_path) {
 function parsePath(cwd, _path) {
   const fullPath = path.join(cwd, _path);
 
-  const parts = _path.split('/');
+  const parts = _path.split(path.sep);
   const userName = parts.pop();
 
   const userPath = parts.length ? path.join(...parts) : '';

--- a/src/lib/project.js
+++ b/src/lib/project.js
@@ -53,7 +53,7 @@ async function project(name) {
   // `-n` (no verify) skips Husky's pre-commit hooks.
   await step(
     'Git init commit',
-    `git add . && git commit -m "Init commit" -q -n && git branch -m main`
+    'git add . && git commit -m "Init commit" -q -n && git branch -m main'
   );
 
   const str =

--- a/src/lib/project.test.js
+++ b/src/lib/project.test.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const path = require('path');
 let {
   project,
   step,
@@ -19,12 +20,16 @@ describe('project.js', () => {
 
   describe('setProjectName()', () => {
     it('README.md contains target text to replace', () => {
-      const readmeTs = fs.readFileSync('templates/project-ts/README.md');
+      const readmeTs = fs.readFileSync(
+        path.join('templates', 'project-ts', 'README.md')
+      );
       expect(readmeTs.includes('Mina SNAPP: PROJECT_NAME')).toBeTruthy();
     });
 
     it('package.json contains target text to replace', () => {
-      const readmeTs = fs.readFileSync('templates/project-ts/package.json');
+      const readmeTs = fs.readFileSync(
+        path.join('templates', 'project-ts', 'package.json')
+      );
       expect(readmeTs.includes('package-name')).toBeTruthy();
     });
 
@@ -36,10 +41,13 @@ describe('project.js', () => {
       fs.writeFileSync(DIR + '/README.md', README);
       fs.writeFileSync(DIR + '/package.json', PKG);
       setProjectName(DIR);
-      const readmeAfter = fs.readFileSync(DIR + '/README.md', 'utf8');
+      const readmeAfter = fs.readFileSync(path.join(DIR, 'README.md'), 'utf8');
       expect(readmeAfter.includes('Temp Fixture Proj')).toBeTruthy();
       expect(readmeAfter.includes('PROJECT_NAME')).toBeFalsy();
-      const packageAfter = fs.readFileSync(DIR + '/package.json', 'utf8');
+      const packageAfter = fs.readFileSync(
+        path.join(DIR, 'package.json'),
+        'utf8'
+      );
       expect(packageAfter.includes('temp-fixture-proj')).toBeTruthy();
       expect(packageAfter.includes('package-name')).toBeFalsy();
       fs.rmSync(DIR, { recursive: true });

--- a/src/postinstall.js
+++ b/src/postinstall.js
@@ -3,6 +3,7 @@
  */
 
 const fs = require('fs');
+const path = require('path');
 const sh = require('shelljs');
 const util = require('util');
 const gittar = require('gittar');
@@ -23,7 +24,10 @@ async function warmNpmCache() {
   console.log('  Warm NPM cache for project template deps.');
 
   // cwd is the root dir where snapp-cli's package.json is located.
-  const tsProj = fs.readFileSync('templates/project-ts/package.json', 'utf8');
+  const tsProj = fs.readFileSync(
+    path.join('templates', 'project-ts', 'package.json'),
+    'utf8'
+  );
 
   let tsProjDeps = {
     ...JSON.parse(tsProj).dependencies,


### PR DESCRIPTION
Fixes https://github.com/o1-labs/snapp-cli/issues/62 and https://github.com/o1-labs/snapp-cli/issues/63

**Description**:
This addresses the issue on Windows when creating a new project or example. A lot of the paths used throughout the project references paths that are not compatible with windows. To address this, `path.join` was used to concatenate paths together.  There is an additional fix with the `git commit` command where it seems to require double quotes on Windows. 

**Tested By**
Tested by running through a manual test with `npm link`. The resulting output has successful steps for both initializing a git repo and setting it up.
```
λ snapp project bar2
√ Fetch project template
√ Initialize Git repo
√ NPM install
√ Set project name
- Git init commit...warning: LF will be replaced by CRLF in .github/workflows/ci.yml.
The file will have its original line endings in your working directory
warning: LF will be replaced by CRLF in .gitignore.
The file will have its original line endings in your working directory
warning: LF will be replaced by CRLF in .husky/pre-commit.
The file will have its original line endings in your working directory
warning: LF will be replaced by CRLF in .prettierignore.
The file will have its original line endings in your working directory
warning: LF will be replaced by CRLF in .prettierrc.
The file will have its original line endings in your working directory
warning: LF will be replaced by CRLF in LICENSE.
The file will have its original line endings in your working directory
warning: LF will be replaced by CRLF in README.md.
The file will have its original line endings in your working directory
warning: LF will be replaced by CRLF in jest.config.js.
The file will have its original line endings in your working directory
warning: LF will be replaced by CRLF in package-lock.json.
The file will have its original line endings in your working directory
warning: LF will be replaced by CRLF in package.json.
The file will have its original line endings in your working directory
warning: LF will be replaced by CRLF in src/index.test.ts.
The file will have its original line endings in your working directory
warning: LF will be replaced by CRLF in src/index.ts.
The file will have its original line endings in your working directory
warning: LF will be replaced by CRLF in tsconfig.json.
The file will have its original line endings in your working directory
√ Git init commit

Success!

Next steps:
  cd bar2
  git remote add origin <your-repo-url>
  git push -u origin main
```
```
λ snapp example sudoku
√ Fetch project template
√ Extract example
√ Initialize Git repo
√ NPM install
√ Set project name
- Git init commit...warning: LF will be replaced by CRLF in .github/workflows/ci.yml.
The file will have its original line endings in your working directory
warning: LF will be replaced by CRLF in .gitignore.
The file will have its original line endings in your working directory
warning: LF will be replaced by CRLF in .husky/pre-commit.
The file will have its original line endings in your working directory
warning: LF will be replaced by CRLF in .prettierignore.
The file will have its original line endings in your working directory
warning: LF will be replaced by CRLF in .prettierrc.
The file will have its original line endings in your working directory
warning: LF will be replaced by CRLF in LICENSE.
The file will have its original line endings in your working directory
warning: LF will be replaced by CRLF in README.md.
The file will have its original line endings in your working directory
warning: LF will be replaced by CRLF in jest.config.js.
The file will have its original line endings in your working directory
warning: LF will be replaced by CRLF in package-lock.json.
The file will have its original line endings in your working directory
warning: LF will be replaced by CRLF in package.json.
The file will have its original line endings in your working directory
warning: LF will be replaced by CRLF in src/index.ts.
The file will have its original line endings in your working directory
warning: LF will be replaced by CRLF in tsconfig.json.
The file will have its original line endings in your working directory
√ Git init commit

Success!

Next steps:
  cd sudoku2
  git remote add origin <your-repo-url>
  git push -u origin main
```
