### PR TITLE
Fix error thrown by yargs on invalid argument and option

### DIFF
--- a/src/bin/index.js
+++ b/src/bin/index.js
@@ -12,54 +12,59 @@ const _g = chalk.green;
 const _r = chalk.reset;
 const _red = chalk.red;
 
-yargs(hideBin(process.argv))
-  .scriptName(_g('snapp'))
-  .usage('Usage: $0 <command> [options]')
-  .strict() // disallow superfluous args
+// Try to protect against commands like `snapp <invalid-cmd> foo` which throws an error in yargs lib
+try {
+  yargs(hideBin(process.argv))
+    .scriptName(_g('snapp'))
+    .usage('Usage: $0 <command> [options]')
+    .strict() // disallow superfluous args
 
-  // https://github.com/yargs/yargs/issues/199
-  // https://github.com/yargs/yargs/blob/master/locales/en.json
-  .updateStrings({
-    'Missing required argument: %s': {
-      one: _red('Missing required argument: %s'),
-    },
-    'Unknown argument: %s': {
-      one: _red('Unknown argument: %s'),
-    },
-  })
-  .demandCommand(1, _red('Please provide a command.'))
+    // https://github.com/yargs/yargs/issues/199
+    // https://github.com/yargs/yargs/blob/master/locales/en.json
+    .updateStrings({
+      'Missing required argument: %s': {
+        one: _red('Missing required argument: %s'),
+      },
+      'Unknown argument: %s': {
+        one: _red('Unknown argument: %s'),
+      },
+    })
+    .demandCommand(1, _red('Please provide a command.'))
 
-  .command(
-    ['project [name]', 'proj [name]', 'p [name]'],
-    'Create a new project',
-    { name: { demand: true, string: true, hidden: true } },
-    async (argv) => await project(argv.name)
-  )
-  .command(
-    ['file [name]', 'f [name]'],
-    'Create a new file & test',
-    { name: { demand: true, string: true, hidden: true } },
-    (argv) => file(argv.name)
-  )
-  .command(
-    ['example [name]', 'e [name]'],
-    'Create an example project',
-    { name: { demand: true, string: true, hidden: true } },
-    async (argv) => await example(argv.name)
-  )
-  .command(['system', 'sys', 's'], 'Show system info', {}, () => system())
-  .alias('h', 'help')
-  .alias('v', 'version')
+    .command(
+      ['project [name]', 'proj [name]', 'p [name]'],
+      'Create a new project',
+      { name: { demand: true, string: true, hidden: true } },
+      async (argv) => await project(argv.name)
+    )
+    .command(
+      ['file [name]', 'f [name]'],
+      'Create a new file & test',
+      { name: { demand: true, string: true, hidden: true } },
+      (argv) => file(argv.name)
+    )
+    .command(
+      ['example [name]', 'e [name]'],
+      'Create an example project',
+      { name: { demand: true, string: true, hidden: true } },
+      async (argv) => await example(argv.name)
+    )
+    .command(['system', 'sys', 's'], 'Show system info', {}, () => system())
+    .alias('h', 'help')
+    .alias('v', 'version')
 
-  .epilog(
-    // _r is a hack to force the terminal to retain a line break below
-    _r(
-      `
+    .epilog(
+      // _r is a hack to force the terminal to retain a line break below
+      _r(
+        `
 
     █▄ ▄█ █ █▄ █ ▄▀▄
     █ ▀ █ █ █ ▀█ █▀█
 
      MINA Protocol
       `
-    )
-  ).argv;
+      )
+    ).argv;
+} catch (_err) {
+  console.log('Usage: $0 <command> [options]');
+}

--- a/src/bin/index.js
+++ b/src/bin/index.js
@@ -12,59 +12,55 @@ const _g = chalk.green;
 const _r = chalk.reset;
 const _red = chalk.red;
 
-// Try to protect against commands like `snapp <invalid-cmd> foo` which throws an error in yargs lib
-try {
-  yargs(hideBin(process.argv))
-    .scriptName(_g('snapp'))
-    .usage('Usage: $0 <command> [options]')
-    .strict() // disallow superfluous args
+yargs(hideBin(process.argv))
+  .scriptName(_g('snapp'))
+  .usage('Usage: $0 <command> [options]')
+  .strictCommands()
+  .strictOptions()
 
-    // https://github.com/yargs/yargs/issues/199
-    // https://github.com/yargs/yargs/blob/master/locales/en.json
-    .updateStrings({
-      'Missing required argument: %s': {
-        one: _red('Missing required argument: %s'),
-      },
-      'Unknown argument: %s': {
-        one: _red('Unknown argument: %s'),
-      },
-    })
-    .demandCommand(1, _red('Please provide a command.'))
+  // https://github.com/yargs/yargs/issues/199
+  // https://github.com/yargs/yargs/blob/master/locales/en.json
+  .updateStrings({
+    'Missing required argument: %s': {
+      one: _red('Missing required argument: %s'),
+    },
+    'Unknown argument: %s': {
+      one: _red('Unknown argument: %s'),
+    },
+  })
+  .demandCommand(1, _red('Please provide a command.'))
 
-    .command(
-      ['project [name]', 'proj [name]', 'p [name]'],
-      'Create a new project',
-      { name: { demand: true, string: true, hidden: true } },
-      async (argv) => await project(argv.name)
-    )
-    .command(
-      ['file [name]', 'f [name]'],
-      'Create a new file & test',
-      { name: { demand: true, string: true, hidden: true } },
-      (argv) => file(argv.name)
-    )
-    .command(
-      ['example [name]', 'e [name]'],
-      'Create an example project',
-      { name: { demand: true, string: true, hidden: true } },
-      async (argv) => await example(argv.name)
-    )
-    .command(['system', 'sys', 's'], 'Show system info', {}, () => system())
-    .alias('h', 'help')
-    .alias('v', 'version')
+  .command(
+    ['project [name]', 'proj [name]', 'p [name]'],
+    'Create a new project',
+    { name: { demand: true, string: true, hidden: true } },
+    async (argv) => await project(argv.name)
+  )
+  .command(
+    ['file [name]', 'f [name]'],
+    'Create a new file & test',
+    { name: { demand: true, string: true, hidden: true } },
+    (argv) => file(argv.name)
+  )
+  .command(
+    ['example [name]', 'e [name]'],
+    'Create an example project',
+    { name: { demand: true, string: true, hidden: true } },
+    async (argv) => await example(argv.name)
+  )
+  .command(['system', 'sys', 's'], 'Show system info', {}, () => system())
+  .alias('h', 'help')
+  .alias('v', 'version')
 
-    .epilog(
-      // _r is a hack to force the terminal to retain a line break below
-      _r(
-        `
+  .epilog(
+    // _r is a hack to force the terminal to retain a line break below
+    _r(
+      `
 
     █▄ ▄█ █ █▄ █ ▄▀▄
     █ ▀ █ █ █ ▀█ █▀█
 
      MINA Protocol
       `
-      )
-    ).argv;
-} catch (_err) {
-  console.log('Usage: $0 <command> [options]');
-}
+    )
+  ).argv;


### PR DESCRIPTION
**Description**:

When using an unknown command, `strict()` will catch the command being wrong but when specifying a wrong command with an option, yargs will throw an error related to https://github.com/o1-labs/snapp-cli/issues/77

To fix this, we remove the `strict()` option and add `strictCommands()` and `strictOptions()`. `strictCommands()` is similar to `strict()` that it applies to unrecognized commands but we also add `strictOptions()` to catch unrecognized options as well. This makes the `snapp-cli` not throw an error when an invalid argument and an invalid option are passed together. 

**Tested**
Manually tested by specifying wrong commands and options.

**Output**
```
$ snapp-cli foo
Usage: snapp <command> [options]

Commands:
  snapp project [name]  Create a new project                  [aliases: proj, p]
  snapp file [name]     Create a new file & test                    [aliases: f]
  snapp example [name]  Create an example project                   [aliases: e]
  snapp system          Show system info                       [aliases: sys, s]

Options:
  -h, --help     Show help                                             [boolean]
  -v, --version  Show version number                                   [boolean]



    █▄ ▄█ █ █▄ █ ▄▀▄
    █ ▀ █ █ █ ▀█ █▀█

     MINA Protocol
      

Unknown command: foo
```
```
$ snapp-cli foo bar
Usage: snapp <command> [options]

...

Unknown commands: foo, bar
```
```
$ snapp-cli project foobar
✔ Fetch project template
✔ Initialize Git repo
✔ NPM install
✔ Set project name
✔ Git init commit

Success!

Next steps:
  cd foobar
  git remote add origin <your-repo-url>
  git push -u origin main
```
