### PR TITLE
Feat: add snarkyjs imports

### DIFF
--- a/src/lib/file.js
+++ b/src/lib/file.js
@@ -39,8 +39,7 @@ async function file(_path) {
     return;
   }
 
-  // TODO: Add SnarkyJS import to fileContent, when it's ready.
-  const fileContent = ``;
+  const fileContent = `import { Field } from '@o1labs/snarkyjs/server';\n`;
   const testContent = `import ${userName} from './${userName}';
 
 describe('${userName}.js', () => {

--- a/src/lib/file.js
+++ b/src/lib/file.js
@@ -39,7 +39,7 @@ async function file(_path) {
     return;
   }
 
-  const fileContent = `import { Field } from '@o1labs/snarkyjs/server';\n`;
+  const fileContent = `// import { Field } from '@o1labs/snarkyjs/server';\n`;
   const testContent = `import ${userName} from './${userName}';
 
 describe('${userName}.js', () => {

--- a/templates/project-ts/package-lock.json
+++ b/templates/project-ts/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.4",
       "license": "Apache-2.0",
       "devDependencies": {
+        "@o1labs/snarkyjs": "^0.1.0",
         "@types/jest": "^26.0.24",
         "husky": "^7.0.1",
         "jest": "^27.0.6",
@@ -867,6 +868,19 @@
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@o1labs/snarkyjs": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@o1labs/snarkyjs/-/snarkyjs-0.1.0.tgz",
+      "integrity": "sha512-BXvVQChi38Q1EK1QkyUAoJLugxTHsCDCRsfk5StP5zAjes1UIUi3xiZE5jItf3vKBI18exHBwLE1pkdctf3eYQ==",
+      "dev": true,
+      "dependencies": {
+        "env": "^0.0.2",
+        "reflect-metadata": "^0.1.13"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/@sinonjs/commons": {
@@ -1737,6 +1751,15 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/env": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/env/-/env-0.0.2.tgz",
+      "integrity": "sha1-UMGfMHsSmkWEW2tobfWzndQNHPA=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.5.9"
       }
     },
     "node_modules/error-ex": {
@@ -4105,6 +4128,12 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
     },
+    "node_modules/reflect-metadata": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
+      "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==",
+      "dev": true
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -5543,6 +5572,16 @@
         "chalk": "^4.0.0"
       }
     },
+    "@o1labs/snarkyjs": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@o1labs/snarkyjs/-/snarkyjs-0.1.0.tgz",
+      "integrity": "sha512-BXvVQChi38Q1EK1QkyUAoJLugxTHsCDCRsfk5StP5zAjes1UIUi3xiZE5jItf3vKBI18exHBwLE1pkdctf3eYQ==",
+      "dev": true,
+      "requires": {
+        "env": "^0.0.2",
+        "reflect-metadata": "^0.1.13"
+      }
+    },
     "@sinonjs/commons": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
@@ -6242,6 +6281,12 @@
       "requires": {
         "ansi-colors": "^4.1.1"
       }
+    },
+    "env": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/env/-/env-0.0.2.tgz",
+      "integrity": "sha1-UMGfMHsSmkWEW2tobfWzndQNHPA=",
+      "dev": true
     },
     "error-ex": {
       "version": "1.3.2",
@@ -8018,6 +8063,12 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true
+    },
+    "reflect-metadata": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
+      "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==",
       "dev": true
     },
     "require-directory": {

--- a/templates/project-ts/package.json
+++ b/templates/project-ts/package.json
@@ -15,6 +15,7 @@
     "format": "prettier --write --ignore-unknown **/*"
   },
   "devDependencies": {
+    "@o1labs/snarkyjs": "^0.1.0",
     "@types/jest": "^26.0.24",
     "husky": "^7.0.1",
     "jest": "^27.0.6",

--- a/templates/project-ts/src/index.ts
+++ b/templates/project-ts/src/index.ts
@@ -1,3 +1,5 @@
+// import { Field } from '@o1labs/snarkyjs/server';
+
 export function foo(): number {
   return 1;
 }


### PR DESCRIPTION
Also import SnarkyJS where appropriate. But then these are commented out to prevent `npm run build` from showing an error because TypeScript doesn't like unused imports. These comments will guide users.