### PR TITLE
Add SnarkyJS to project 

### DIFF
--- a/src/lib/system.js
+++ b/src/lib/system.js
@@ -7,7 +7,7 @@ function system() {
       {
         System: ['OS', 'CPU'],
         Binaries: ['Node', 'npm', 'Yarn'],
-        npmPackages: ['@o1labs/snarkyjs-web'],
+        npmPackages: ['snarkyjs'],
         npmGlobalPackages: ['snapp-cli'],
       },
       { showNotFound: true }

--- a/templates/project-ts/package-lock.json
+++ b/templates/project-ts/package-lock.json
@@ -14,6 +14,7 @@
         "jest": "^27.0.6",
         "lint-staged": "^11.0.1",
         "prettier": "^2.3.2",
+        "snarkyjs": "^0.1.9",
         "ts-jest": "^27.0.4",
         "typescript": "^4.3.5"
       }
@@ -1737,6 +1738,15 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/env": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/env/-/env-0.0.2.tgz",
+      "integrity": "sha1-UMGfMHsSmkWEW2tobfWzndQNHPA=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.5.9"
       }
     },
     "node_modules/error-ex": {
@@ -4105,6 +4115,12 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
     },
+    "node_modules/reflect-metadata": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
+      "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==",
+      "dev": true
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -4282,6 +4298,29 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/snarkyjs": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.1.9.tgz",
+      "integrity": "sha512-iLkU6IQ3xY7aZzeiR2sPJIN0eCMSEju1w85KHI2YMgrhQx9GVb39A7hpp9/kZ20MvXkkwZ3byrR4fW4EGwYCYw==",
+      "dev": true,
+      "dependencies": {
+        "env": "^0.0.2",
+        "reflect-metadata": "^0.1.13",
+        "tslib": "^2.3.0"
+      },
+      "bin": {
+        "snarky-run": "src/build/run.mjs"
+      },
+      "engines": {
+        "node": ">=16.4.0"
+      }
+    },
+    "node_modules/snarkyjs/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
     },
     "node_modules/source-map": {
       "version": "0.6.1",
@@ -6243,6 +6282,12 @@
         "ansi-colors": "^4.1.1"
       }
     },
+    "env": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/env/-/env-0.0.2.tgz",
+      "integrity": "sha1-UMGfMHsSmkWEW2tobfWzndQNHPA=",
+      "dev": true
+    },
     "error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -8020,6 +8065,12 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
     },
+    "reflect-metadata": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
+      "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==",
+      "dev": true
+    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -8154,6 +8205,25 @@
         "ansi-styles": "^4.0.0",
         "astral-regex": "^2.0.0",
         "is-fullwidth-code-point": "^3.0.0"
+      }
+    },
+    "snarkyjs": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.1.9.tgz",
+      "integrity": "sha512-iLkU6IQ3xY7aZzeiR2sPJIN0eCMSEju1w85KHI2YMgrhQx9GVb39A7hpp9/kZ20MvXkkwZ3byrR4fW4EGwYCYw==",
+      "dev": true,
+      "requires": {
+        "env": "^0.0.2",
+        "reflect-metadata": "^0.1.13",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
       }
     },
     "source-map": {

--- a/templates/project-ts/package.json
+++ b/templates/project-ts/package.json
@@ -5,8 +5,9 @@
   "author": "",
   "license": "Apache-2.0",
   "keywords": [],
-  "main": "build/index.js",
-  "types": "build/index.d.ts",
+  "main": "build/src/index.js",
+  "types": "build/src/index.d.ts",
+  "type": "module",
   "scripts": {
     "test": "jest",
     "testw": "jest --watch",
@@ -22,7 +23,8 @@
     "lint-staged": "^11.0.1",
     "prettier": "^2.3.2",
     "ts-jest": "^27.0.4",
-    "typescript": "^4.3.5"
+    "typescript": "^4.3.5",
+    "snarkyjs": "^0.1.9"
   },
   "lint-staged": {
     "**/*": [

--- a/templates/project-ts/src/index.ts
+++ b/templates/project-ts/src/index.ts
@@ -1,3 +1,4 @@
+// import * as SnarkyJS from 'snarkyjs';
 export function foo(): number {
   return 1;
 }

--- a/templates/project-ts/tsconfig.json
+++ b/templates/project-ts/tsconfig.json
@@ -2,13 +2,24 @@
   "compilerOptions": {
     "target": "ES2019",
     "module": "ES2020",
+    "lib": ["dom", "esnext"],
     "outDir": "./build",
-    "rootDir": "./src",
-    "declaration": true,
+    "rootDir": ".",
     "strict": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "allowJs": true,
+    "importHelpers": true,
+    "declaration": true,
+    "sourceMap": false,
+    "noFallthroughCasesInSwitch": true,
+    "allowSyntheticDefaultImports": true,
+    "isolatedModules": true
   },
+  "include": ["./src"],
   "exclude": ["./src/**/*.test.ts"]
 }


### PR DESCRIPTION
**Description**

This PR adds SnarkyJS to the project as an NPM dependency. Users will now be able to create a project and have Snarky available right away and start building. 

**Changes**
- Adds SnarkyJS to package.json
- Changes tsconfig.json to support SnarkyJS

**Left to do**
This PR has not implemented Jest tests to work yet. This has been a challenge with Jests runtime expects packages from node_modules to be in CJS format and if they are not, it tries to transform them on runtime. Both these approaches have been causing issues and in the spirit of unblocking others on this change, I will follow up on adding Jest in another PR.