### PR TITLE
fetch examples all the time, fallback on local

### DIFF
--- a/src/lib/example.js
+++ b/src/lib/example.js
@@ -81,7 +81,7 @@ async function fetchProjectTemplate(name, lang) {
 
   try {
     const src = 'github:o1-labs/snapp-cli#main';
-    await gittar.fetch(src);
+    await gittar.fetch(src, { force: true });
 
     // Note: Extract will overwrite any existing dir's contents. But we're
     // using an always-unique name.


### PR DESCRIPTION
see https://github.com/lukeed/gittar#optionsforce

> Force a HTTPS download. If there is an error with the network request, a local/cache lookup will follow.