### PR TITLE
added script to build & run the built index

### DIFF
--- a/templates/project-ts/package.json
+++ b/templates/project-ts/package.json
@@ -13,6 +13,7 @@
     "testw": "jest --watch",
     "coverage": "jest --coverage",
     "build": "tsc -p tsconfig.json",
+    "exec": "tsc -p tsconfig.json && node build/src/index.js",
     "prepare": "husky install",
     "format": "prettier --write --ignore-unknown **/*"
   },


### PR DESCRIPTION
not sure if this is a good thing because, what if we have different main files? Also I think we were discussing using `npm run start` instead of `npm run exec` somewhere else which might be more idiomatic?