### PR TITLE
Add example contract that adds 1 + 2

### DIFF
--- a/templates/project-ts/package-lock.json
+++ b/templates/project-ts/package-lock.json
@@ -14,7 +14,7 @@
         "jest": "^27.0.6",
         "lint-staged": "^11.0.1",
         "prettier": "^2.3.2",
-        "snarkyjs": "^0.1.9",
+        "snarkyjs": "^0.1.11",
         "ts-jest": "^27.0.4",
         "typescript": "^4.3.5"
       }
@@ -4300,9 +4300,9 @@
       }
     },
     "node_modules/snarkyjs": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.1.9.tgz",
-      "integrity": "sha512-iLkU6IQ3xY7aZzeiR2sPJIN0eCMSEju1w85KHI2YMgrhQx9GVb39A7hpp9/kZ20MvXkkwZ3byrR4fW4EGwYCYw==",
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.1.11.tgz",
+      "integrity": "sha512-fXt6nVO8uL9w/ZH2y/9jN0heUEj6qpIlazt2kBewm0jeS4lCN2K0uMOUcxxjf97vKTYsKjGuEv+ZUK6xnQJZtw==",
       "dev": true,
       "dependencies": {
         "env": "^0.0.2",
@@ -8208,9 +8208,9 @@
       }
     },
     "snarkyjs": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.1.9.tgz",
-      "integrity": "sha512-iLkU6IQ3xY7aZzeiR2sPJIN0eCMSEju1w85KHI2YMgrhQx9GVb39A7hpp9/kZ20MvXkkwZ3byrR4fW4EGwYCYw==",
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/snarkyjs/-/snarkyjs-0.1.11.tgz",
+      "integrity": "sha512-fXt6nVO8uL9w/ZH2y/9jN0heUEj6qpIlazt2kBewm0jeS4lCN2K0uMOUcxxjf97vKTYsKjGuEv+ZUK6xnQJZtw==",
       "dev": true,
       "requires": {
         "env": "^0.0.2",

--- a/templates/project-ts/package.json
+++ b/templates/project-ts/package.json
@@ -24,7 +24,7 @@
     "prettier": "^2.3.2",
     "ts-jest": "^27.0.4",
     "typescript": "^4.3.5",
-    "snarkyjs": "^0.1.9"
+    "snarkyjs": "^0.1.11"
   },
   "lint-staged": {
     "**/*": [

--- a/templates/project-ts/src/index.test.ts
+++ b/templates/project-ts/src/index.test.ts
@@ -1,9 +1,5 @@
-import { foo } from './index';
-
 describe('index.ts', () => {
   describe('foo()', () => {
-    it('should be correct', () => {
-      expect(foo()).toEqual(1);
-    });
+    it.todo('should be correct');
   });
 });

--- a/templates/project-ts/src/index.ts
+++ b/templates/project-ts/src/index.ts
@@ -1,4 +1,37 @@
-// import * as SnarkyJS from 'snarkyjs';
-export function foo(): number {
-  return 1;
+import {
+  Field,
+  PublicKey,
+  SmartContract,
+  state,
+  State,
+  method,
+  UInt64,
+} from 'snarkyjs';
+
+/**
+ * Basic Example
+ * See https://docs.minaprotocol.com/snapps for more info.
+ *
+ * The Add contract initializes the state variable 'num' to be a Field(1) value by default when deployed.
+ * When the 'update' method is called, the Add contract adds Field(2) to its 'num' contract state.
+ */
+class Add extends SmartContract {
+  @state(Field) num: State<Field>;
+
+  constructor(
+    initialBalance: UInt64,
+    address: PublicKey,
+    num: Field = Field(1)
+  ) {
+    super(address);
+    this.balance.addInPlace(initialBalance);
+    this.num = State.init(num);
+  }
+
+  @method async update() {
+    const currentState = await this.num.get();
+    const newState = currentState.add(2);
+    newState.assertEquals(currentState.add(2));
+    this.num.set(newState);
+  }
 }


### PR DESCRIPTION
**Description**

Add an example contract that adds the Field elements 1 + 2.

**Note**
The test file in the `templates/project-ts` has not been updated as it depends on https://github.com/o1-labs/snapp-cli/pull/100 to land. Tests can be added in a follow-up PR.

**Tested**
Ran `npm run build` and builds successfully
Ran `node build/src/index.js` no errors are shown