### PR TITLE
fix: use root eslint config

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "lint-staged": {
     "**/*": [
-      "eslint src/* --fix",
+      "eslint -c .eslintrc.js src/* --fix",
       "prettier --write --ignore-unknown"
     ]
   },


### PR DESCRIPTION
Without specifying the eslint config to use, eslint looks for all configs (including the child project) and consequently complains about missing the snarkyjs custom eslint plugin. Specifying which eslint config to use fixes this.